### PR TITLE
Fix Error Handler receives an instance of Throwable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bugphix/bugphix-laravel",
+    "name": "ihos/bugphix-laravel",
     "description": "Capture and monitor detailed error logs with nice dashboard and UI.",
     "keywords": [
         "bugphix",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ihos/bugphix-laravel",
+    "name": "bugphix/bugphix-laravel",
     "description": "Capture and monitor detailed error logs with nice dashboard and UI.",
     "keywords": [
         "bugphix",

--- a/src/Bugphix.php
+++ b/src/Bugphix.php
@@ -3,7 +3,7 @@
 namespace Bugphix\BugphixLaravel;
 
 use GuzzleHttp\Client as GuzzleClient;
-use Exception;
+use Throwable;
 use Log;
 
 //traits
@@ -34,7 +34,7 @@ class Bugphix
         }
     }
 
-    public function catchError(Exception $e)
+    public function catchError(Throwable $e)
     {
         // $timeStart = microtime(true);
         $this->setProject();
@@ -68,7 +68,7 @@ class Bugphix
                 ]);
 
                 Log::info($res->getBody());
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 dd($e);
             }
         }


### PR DESCRIPTION
Fix Line: 37 – /vendor/bugphix/bugphix-laravel/src/Bugphix.php

Details: Argument 1 passed to Bugphix\BugphixLaravel\Bugphix::catchError() must be an instance of Exception, instance of TypeError given, called in

Errors and Exceptions both extend Throwable however Errors are not extended from Exception.

Handler receives an instance of Throwable
Function in \app\Exceptions\Handler.php
public function report (Throwable $ exception)